### PR TITLE
Don't list all project names in command usage help

### DIFF
--- a/src/CloneLeeroy/ProjectSuggestionSource.cs
+++ b/src/CloneLeeroy/ProjectSuggestionSource.cs
@@ -13,6 +13,10 @@ namespace CloneLeeroy
 
 		public IEnumerable<string?> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null)
 		{
+			// HACK: if no parseResult is supplied, assume this is being invoked from the HelpBuilder (i.e., --help) and avoid spamming the output with all the project names
+			if (parseResult is null)
+				return Enumerable.Empty<string?>();
+
 			m_files ??= Directory.GetFiles(m_configurationPath, "*.json").Select(x => Path.GetFileNameWithoutExtension(x)).ToArray();
 			return m_files.Where(x => string.IsNullOrEmpty(textToMatch) || x.IndexOf(textToMatch, StringComparison.OrdinalIgnoreCase) != -1);
 		}


### PR DESCRIPTION
Fixes https://github.com/Faithlife/CloneLeeroy/issues/4 with a hack. Seems to work in practice... with the current version of System.CommandLine.

(The right way might be to inject a `HelpBuilderFactory` that creates a custom `HelpBuilder` that doesn't use the suggestions to build the help: https://github.com/dotnet/command-line-api/blob/4b43131a66cb675d681f23254a08a7e3d34a7e6f/src/System.CommandLine/Help/HelpBuilder.cs#L535-L539.)